### PR TITLE
fix mariadb command line syntax again

### DIFF
--- a/data/Dockerfiles/dovecot/docker-entrypoint.sh
+++ b/data/Dockerfiles/dovecot/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Wait for MySQL to warm-up
-while ! mariadb-admin status --ssl=false --host=${DBHOST} --port=${DBPORT} --user=${DBUSER} --password${DBPASS} --silent; do
+while ! mariadb-admin status --ssl=false --host=${DBHOST} --port=${DBPORT} --user=${DBUSER} --password=${DBPASS} --silent; do
   echo "Waiting for database to come up..."
   sleep 2
 done


### PR DESCRIPTION
Fixes a typo introduced in fce0b036a8ad660368855abf68da592b0b97f5f9  